### PR TITLE
Sort published snippets by timestamp

### DIFF
--- a/lib/weekly_snippets/publisher.rb
+++ b/lib/weekly_snippets/publisher.rb
@@ -32,7 +32,10 @@ module WeeklySnippets
     end
 
     # Processes +snippets+ entries for publication. Any snippets that should
-    # not appear when in +public_mode+ are removed from +snippets+
+    # not appear when in +public_mode+ are removed from +snippets+. The keys
+    # of the resulting hash will be sorted in nondecreasing order.
+    # @param snippets [Hash<String,Hash>] timestamp => batch of snippets
+    # @return [Hash<String,Hash>]
     def publish(snippets)
       result = {}
       snippets.each do |timestamp, snippet_batch|
@@ -44,7 +47,7 @@ module WeeklySnippets
         end
         result[timestamp] = published unless published.empty?
       end
-      result
+      result.sort.to_h
     end
 
     # Parses and publishes a snippet. Filters out snippets rendered empty

--- a/test/publisher_publish_test.rb
+++ b/test/publisher_publish_test.rb
@@ -54,19 +54,23 @@ module WeeklySnippets
     end
 
     def test_publish_all_snippets
-      add_snippet('20141218', make_snippet(['- Did stuff']))
-      add_snippet('20141225', make_snippet(['- Did stuff']))
-      add_snippet('20141231', make_snippet(['- Did stuff']))
       add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
-      assert_equal @expected, publisher.publish(@original)
+      add_snippet('20141218', make_snippet(['- Did stuff']))
+      add_snippet('20141231', make_snippet(['- Did stuff']))
+      add_snippet('20141225', make_snippet(['- Did stuff']))
+      published = publisher.publish(@original)
+      assert_equal @expected, published
+      assert_equal @expected.keys.sort, published.keys
     end
 
     def test_publish_only_public_snippets_in_public_mode
-      add_snippet('20141218', make_snippet(['- Did stuff']), expected: false)
-      add_snippet('20141225', make_snippet(['- Did stuff']), expected: false)
-      add_snippet('20141231', make_snippet(['- Did stuff']), expected: false)
       add_snippet('20150107', make_snippet(['- Did stuff'], is_public: true))
-      assert_equal @expected, publisher(public_mode: true).publish(@original)
+      add_snippet('20141218', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141231', make_snippet(['- Did stuff']), expected: false)
+      add_snippet('20141225', make_snippet(['- Did stuff']), expected: false)
+      published = publisher(public_mode: true).publish(@original)
+      assert_equal @expected, published
+      assert_equal @expected.keys.sort, published.keys
     end
   end
 end


### PR DESCRIPTION
Noticed that the automatically-deployed internal Hub has its snippet batches listed out of order: https://hub.18f.us//snippets/

I could just update one of the Hub plugins, but it seemed like updating this API would follow the principle of least surprise. Could be persuaded otherwise, though.

cc: @adelevie @afeld
